### PR TITLE
Fix workflow reusability by adding workflow_call trigger

### DIFF
--- a/.github/workflows/jekyll.yml
+++ b/.github/workflows/jekyll.yml
@@ -9,6 +9,9 @@ on:
 # 允許手動觸發工作流程
   workflow_dispatch:
 
+# 允許作為可重用工作流程被其他工作流程調用
+  workflow_call:
+
 # 設定權限以允許部署到 GitHub Pages
 permissions:
   contents: read


### PR DESCRIPTION
- 在 jekyll.yml 添加 `on.workflow_call` 觸發器
- 允許此工作流程作為可重用工作流程被其他工作流程調用
- 修復 fully-auto-content.yml 在第 358 行調用時的錯誤

Fixes: workflow is not reusable as it is missing a `on.workflow_call` trigger