### PR TITLE
Fix missing assets/images directory error

### DIFF
--- a/.github/workflows/auto-fix.yml
+++ b/.github/workflows/auto-fix.yml
@@ -196,9 +196,15 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y optipng jpegoptim
 
-          # 優化圖片
-          find assets/images -name "*.png" -exec optipng -o2 {} \;
-          find assets/images -name "*.jpg" -exec jpegoptim --max=85 {} \;
+          # 優化圖片（如果目錄存在）
+          if [ -d "assets/images" ]; then
+            echo "優化 assets/images 目錄中的圖片..."
+            find assets/images -name "*.png" -exec optipng -o2 {} \;
+            find assets/images -name "*.jpg" -exec jpegoptim --max=85 {} \;
+            echo "圖片優化完成"
+          else
+            echo "assets/images 目錄不存在，跳過圖片優化"
+          fi
 
       - name: 📦 Check for large files
         run: |


### PR DESCRIPTION
- 在圖片優化步驟中添加目錄存在性檢查
- 當 assets/images 目錄不存在時，優雅地跳過優化步驟
- 防止工作流程因缺少目錄而失敗

修復錯誤: find: 'assets/images': No such file or directory