### PR TITLE
Fix GitHub Actions permission error for auto-content

### DIFF
--- a/.github/workflows/auto-content.yml
+++ b/.github/workflows/auto-content.yml
@@ -29,6 +29,10 @@ jobs:
   generate-content:
     name: 📝 Generate Articles
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
 
     steps:
       - name: 📥 Checkout code


### PR DESCRIPTION
添加必要的工作流程權限以允許 github-actions[bot] 推送和創建 PR：
- contents: write - 允許推送到儲存庫
- pull-requests: write - 允許創建拉取請求
- issues: write - 允許創建問題

修復錯誤：
remote: Permission to justin2061/idea-hub.git denied to github-actions[bot]. fatal: unable to access 'https://github.com/justin2061/idea-hub/': The requested URL returned error: 403

相關工作流程：.github/workflows/auto-content.yml