### PR TITLE
Fix pull request creation authorization error

### DIFF
--- a/.github/workflows/auto-fix.yml
+++ b/.github/workflows/auto-fix.yml
@@ -13,6 +13,7 @@ on:
 # 設定必要的權限
 permissions:
   contents: write
+  pull-requests: write
   issues: write
   actions: read
 


### PR DESCRIPTION
Resolves "Resource not accessible by integration" error when creating pull requests.

The peter-evans/create-pull-request action requires the pull-requests: write permission to create PRs. This was missing from the auto-fix.yml workflow permissions.

Changes:
- Added pull-requests: write to workflow permissions

Related to: auto-optimize/performance-26 branch PR creation failure