### PR TITLE
Fix GitHub Actions pull request permissions

### DIFF
--- a/.github/workflows/auto-content.yml
+++ b/.github/workflows/auto-content.yml
@@ -198,7 +198,6 @@ jobs:
             auto-generated
             content
             needs-review
-          reviewers: ${{ github.actor }}
 
       - name: 📊 Summary
         if: always()

--- a/.github/workflows/auto-fix.yml
+++ b/.github/workflows/auto-fix.yml
@@ -123,7 +123,6 @@ jobs:
             auto-fix
             automated
             auto-merge
-          reviewers: ${{ github.actor }}
 
       - name: 📊 PR Created Summary
         if: steps.create_pr.outputs.pull-request-number


### PR DESCRIPTION
…ions issues

GitHub Actions using GITHUB_TOKEN cannot add reviewers to pull requests. This commit removes the `reviewers` field from workflow configurations to prevent permission errors.

Changes:
- Removed reviewers field from auto-fix.yml
- Removed reviewers field from auto-content.yml

This allows the workflows to create PRs without requiring approval permissions.