### PR TITLE
Add web tracking implementation

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -59,6 +59,15 @@ social:
   links:
     - "https://github.com/justin2061"
 
+# =============================
+# Analytics 追蹤
+# =============================
+analytics:
+  provider: "google-gtag"
+  google:
+    tracking_id: "G-7BX9M8J5K4"
+    anonymize_ip: false
+
 # 搜尋功能
 search: true
 search_full_content: true


### PR DESCRIPTION
- 在 _config.yml 中配置 GA4 追蹤代碼 (G-7BX9M8J5K4)
- 使用 google-gtag provider 以支持 GA4 新版追蹤
- 啟用網站流量分析與使用者行為追蹤